### PR TITLE
chore(cla): add/ensure required CLA trigger stub

### DIFF
--- a/.github/workflows/cla-check-trigger.yml
+++ b/.github/workflows/cla-check-trigger.yml
@@ -1,39 +1,57 @@
-# This file is auto-generated and managed by the organization's .github repository.
-# Do not modify manually. Version: 1.1.0
-name: CLA Check Trigger
+# Auto-managed; DO NOT EDIT MANUALLY
+# Stub Version: 7
+name: CLA — Trigger Stub
 
 on:
-  # Trigger on pull request events (opened, new commits pushed, reopened)
   pull_request_target:
     types: [opened, synchronize, reopened]
-  # Trigger on issue comments (pull requests are also 'issues' in GitHub's model)
   issue_comment:
-    types: [created] # Only when a new comment is made
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
-  call_cla_check:
-    # This job will run if:
-    # 1. The event is 'pull_request_target'.
-    # OR
-    # 2. The event is 'issue_comment' AND the comment was made on a pull request.
-    # The 'contributor-assistant/github-action' in the reusable workflow will then
-    # determine if the comment body is relevant for CLA signing or rechecking.
+  guard:
+    name: Gate & Dispatch
+    runs-on: ubuntu-latest
     if: >
-      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'pull_request_target') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request)
 
-    # Call the organization's centralized reusable CLA checking workflow.
-    # Pinning to a specific versioned tag (e.g., @v1.0.0) or commit SHA of the reusable workflow is highly recommended for stability.
-    uses: vmware/.github/.github/workflows/reusable-cla-check.yml@main
-    secrets:
-      # Pass the PAT required by contributor-assistant. This PAT needs permissions for:
-      # - PR interactions (comments, labels, statuses) on THIS repository (where the stub runs).
-      # - Contents Read & Write on the vmware/.github repository to manage the CLA.csv signature file.
-      CONTRIBUTOR_ASSISTANT_PAT: ${{ secrets.CLA_ASSISTANT_PAT }} # Note: Secret name is still CLA_ASSISTANT_PAT as per previous setup
-                                                                 # Can be renamed if desired, but ensure consistency.
-    with:
-      # Provide the URL to the CLA document.
-      cla_document_url: https://github.com/vmware/.github/blob/main/.github/CONTRIBUTOR_LICENSE_AGREEMENT.md # Using the default determined in Python script
-      # Optional overrides for signature file path and branch if defaults in reusable workflow are not suitable:
-      # signature_file_path: '.github/signatures/CLA.csv'
-      # signature_branch: 'main'
+    steps:
+      - name: Short-circuit for org members (fast path)
+        id: member
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let isMember = false;
+            try {
+              await github.rest.orgs.checkMembershipForUser(
+                { org: context.repo.owner, username: context.payload.sender.login }
+              );
+              isMember = true;
+            } catch {}
+            core.setOutput('is_member', isMember ? 'true' : 'false');
+
+      - name: Skip if org member
+        if: ${{ steps.member.outputs.is_member == 'true' }}
+        run: echo "Org member — skipping CLA."
+
+      - name: Call reusable CLA checker
+        if: ${{ steps.member.outputs.is_member != 'true' }}
+        uses: ${{ github.repository_owner }}/.github/.github/workflows/reusable-cla-check.yml@main
+        with:
+          allowlist_branch: "main"
+          allowlist_path: "cla/allowlist.yml"
+          sign_comment_exact: "I have read the CLA Document and I hereby sign the CLA"
+        secrets:
+          CONTRIBUTOR_ASSISTANT_PAT: ${{ secrets.CLA_ASSISTANT_PAT }}


### PR DESCRIPTION
**CLA stub addition/update**

- Reason: CLA required for this repository
- Managed by automation branch `automation/cla-stub`
- Stub version: `7`

This PR is generated by the org CLA manager to keep every repo aligned with the central CLA policy.