### PR TITLE
chore(cla): add/ensure required CLA trigger stub

### DIFF
--- a/.github/workflows/cla-check-trigger.yml
+++ b/.github/workflows/cla-check-trigger.yml
@@ -1,5 +1,5 @@
 # Auto-managed; DO NOT EDIT MANUALLY
-# Stub Version: 11
+# Stub Version: 12
 name: CLA — Trigger
 
 on:
@@ -9,7 +9,12 @@ on:
     types: [created]
 
 # Keep the stub minimal; the reusable owns permissions & concurrency
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write
+  actions: read
 
 jobs:
   cla:


### PR DESCRIPTION
**CLA stub addition/update**

- Reason: CLA required for this repository
- Managed by automation branch `automation/cla-stub`
- Stub version: `12`

This PR is generated by the org CLA manager to keep every repo aligned with the central CLA policy.