### PR TITLE
chore(cla): add/ensure required CLA trigger stub

### DIFF
--- a/.github/workflows/cla-check-trigger.yml
+++ b/.github/workflows/cla-check-trigger.yml
@@ -1,5 +1,5 @@
 # Auto-managed; DO NOT EDIT MANUALLY
-# Stub Version: 13
+# Stub Version: 14
 name: CLA — Trigger
 
 on:
@@ -8,23 +8,21 @@ on:
   issue_comment:
     types: [created, edited]
 
-≈
 jobs:
   cla:
     name: Call reusable CLA checker
     # run on PRs, or when a signing comment *or* recheck is posted
     if: >
-      ${
-        github.event_name == 'pull_request_target' ||
-        (
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
+      ${ github.event_name == 'pull_request_target' ||
           (
-            contains(github.event.comment.body, { sign_comment_exact | tojson }) ||
-            startsWith(github.event.comment.body, 'recheck') ||
-            startsWith(github.event.comment.body, '/recheck')
+            github.event_name == 'issue_comment' &&
+            github.event.issue.pull_request &&
+            (
+              contains(github.event.comment.body, { sign_comment_exact | tojson }) ||
+              startsWith(github.event.comment.body, 'recheck') ||
+              startsWith(github.event.comment.body, '/recheck')
+            )
           )
-        )
       }
    permissions:
         contents: read


### PR DESCRIPTION
**CLA stub addition/update**

- Reason: CLA required for this repository
- Managed by automation branch `automation/cla-stub`
- Stub version: `14`

This PR is generated by the org CLA manager to keep every repo aligned with the central CLA policy.