### PR TITLE
fix(cla): store signatures in dedicated cla-signatures branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -68,5 +68,5 @@ jobs:
         with:
           path-to-document: 'https://github.com/vmware/oss-public-policy/blob/main/Broadcom_CLA.md'
           path-to-signatures: 'signatures/version1/cla.json'
-          branch: 'main'
+          branch: 'cla-signatures'
           allowlist: 'bot*, dependabot[bot]'


### PR DESCRIPTION
Update path-to-signatures target branch from main to cla-signatures to prevent branch protection rule conflicts.