### PR TITLE
fix(cla): follow redirects in org membership check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,7 +37,7 @@ jobs:
           echo "=========================================="
 
           # API call to check membership
-          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+          RESPONSE=$(curl -sL -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/orgs/$TARGET_ORG/members/$PR_AUTHOR")


### PR DESCRIPTION
Updates the curl command in the Check Org Membership step by adding the -L flag. This ensures curl follows any HTTP 302 redirects from the GitHub API and returns the final 204 No Content status code for org members.