### PR TITLE
ci: add local compliance test workflow with APP_TOKEN env pass  Add r…

### DIFF
--- a/.github/workflows/required-compliance-local-test.yml
+++ b/.github/workflows/required-compliance-local-test.yml
@@ -3,7 +3,7 @@ name: Legal Compliance Gate
 # We use 'pull_request_target' so Fork PRs can access the Secrets
 # needed to check the database in the Mothership.
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/required-compliance-local-test.yml
+++ b/.github/workflows/required-compliance-local-test.yml
@@ -1,0 +1,96 @@
+name: Legal Compliance Gate
+
+# We use 'pull_request_target' so Fork PRs can access the Secrets
+# needed to check the database in the Mothership.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  policy-enforcement:
+    name: Check CLA/DCO
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write # Needed to post comments
+      statuses: write      # Needed to set status checks
+      checks: write
+
+    steps:
+      # 1. GENERATE TOKEN
+      # We need this to authenticate with the Mothership repo to fetch signatures.
+      - name: Generate Mothership Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CLA_APP_ID }}
+          private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
+          owner: ${{ vars.CENTRAL_ORG }}
+
+      # 2. CHECKOUT TOOLS
+      # We download the scripts from your central .github repo.
+      - name: Checkout Mothership Tools
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.CENTRAL_ORG }}/.github
+          token: ${{ steps.app-token.outputs.token }}
+          path: .github-tools
+          ref: main
+          sparse-checkout: |
+            scripts
+
+            
+      # 3. SETUP PYTHON
+      - name: Setup Python & Cache
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Cache Pip Packages
+        uses: actions/cache@v4
+        id: pip-cache
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-compliance-v1
+          restore-keys: |
+            ${{ runner.os }}-pip-compliance-
+
+      # 4. INSTALL DEPENDENCIES
+      # We include rapidfuzz/aiohttp because your 'requires_cla.py' helper needs them.
+      - name: Install Dependencies
+        run: pip install pyyaml PyJWT cryptography rapidfuzz aiohttp requests
+
+      # 5. RUN COMPLIANCE CHECK
+      # This single step now handles everything: 
+      # - Detects Policy
+      # - Checks Signature
+      # - Posts Comment (if missing)
+      # - Fails Build (if missing)
+      - name: Verify Compliance
+        id: policy
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          CLA_APP_ID: ${{ secrets.CLA_APP_ID }}
+          CLA_APP_PRIVATE_KEY: ${{ secrets.CLA_APP_PRIVATE_KEY }}
+          
+          # Auth & Context
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
+          CENTRAL_ORG: ${{ vars.CENTRAL_ORG }}
+          
+          # Paths for Python to find your scripts & data
+          TOOLS_PATH: ${{ github.workspace }}/.github-tools
+          PYTHONPATH: ${{ github.workspace }}/.github-tools/scripts
+          LICENSES_JSON: ${{ github.workspace }}/.github-tools/data/licenses_all.json
+          
+          # Documentation Links (Used in the failure comment)
+          CLA_DOC_URL: "https://${{ vars.CENTRAL_ORG }}.github.io/oss-public-policy/Broadcom_CLA"
+          DCO_DOC_URL: "https://${{ vars.CENTRAL_ORG }}.github.io/oss-public-policy/DCO_1.1"
+          
+        # We run the UPDATED policy_selector.py which includes the validation logic
+        run: python .github-tools/scripts/policy_selector.py
+
+        
+          


### PR DESCRIPTION
…equired-compliance-local-test.yml to verify that passing  APP_TOKEN from steps.app-token.outputs.token resolves private  organization membership verification in policy_selector.py.

## Summary
This PR introduces a local, isolated copy of the compliance workflow (`.github/workflows/required-compliance-local-test.yml`) to test a proposed fix for private organization member verification.

## The Fix
* Added `APP_TOKEN: ${{ steps.app-token.outputs.token }}` to the environment variables under Step 5 (`Verify Compliance`).
* This allows `policy_selector.py` to receive the generated GitHub App Installation Access Token rather than falling back to `GITHUB_TOKEN`.

## Verification Steps
1. Trigger this workflow on a PR opened by an organization member with private membership.
2. Verify that `policy_selector.py` successfully reads `APP_TOKEN`.
3. Confirm that the GitHub API returns `HTTP 204` (Member Verified) instead of failing with `HTTP 404`.

> **Note:** Once validated in this test repo, a matching PR will be submitted to the central `vmware/.github` repository to apply the fix globally.